### PR TITLE
download survey metadata

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/udd/config/SpringConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/config/SpringConfig.java
@@ -70,9 +70,9 @@ public class SpringConfig {
         return ddbClient().getTable(environmentConfig().get("synapse.map.table"));
     }
 
-    @Bean(name = "ddbUploadTable")
-    public Table ddbUploadTable() {
-        return ddbClient().getTable(ddbPrefix() + "Upload2");
+    @Bean(name = "ddbSynapseSurveyTable")
+    public Table ddbSynapseSurveyTable() {
+        return ddbClient().getTable(ddbPrefix() + "SynapseSurveyTables");
     }
 
     @Bean(name = "ddbUploadSchemaTable")

--- a/src/main/java/org/sagebionetworks/bridge/udd/config/SpringConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/config/SpringConfig.java
@@ -70,8 +70,10 @@ public class SpringConfig {
         return ddbClient().getTable(environmentConfig().get("synapse.map.table"));
     }
 
-    @Bean(name = "ddbSynapseSurveyTable")
-    public Table ddbSynapseSurveyTable() {
+    // Naming note: This is a DDB table containing references to a set of Synapse tables. The name is a bit confusing,
+    // but I'm not sure how to make it less confusing.
+    @Bean(name = "ddbSynapseSurveyTablesTable")
+    public Table ddbSynapseSurveyTablesTable() {
         return ddbClient().getTable(ddbPrefix() + "SynapseSurveyTables");
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/udd/dynamodb/DynamoHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/dynamodb/DynamoHelper.java
@@ -23,7 +23,7 @@ public class DynamoHelper {
     private Table ddbHealthIdTable;
     private Table ddbStudyTable;
     private Table ddbSynapseMapTable;
-    private Table ddbSynapseSurveyTable;
+    private Table ddbSynapseSurveyTablesTable;
     private Table ddbUploadSchemaTable;
     private Index ddbUploadSchemaStudyIndex;
 
@@ -45,10 +45,14 @@ public class DynamoHelper {
         this.ddbSynapseMapTable = ddbSynapseMapTable;
     }
 
-    /** DDB table that gets the list of all survey tables for a given study. */
-    @Resource(name = "ddbSynapseSurveyTable")
-    public final void setDdbSynapseSurveyTable(Table ddbSynapseSurveyTable) {
-        this.ddbSynapseSurveyTable = ddbSynapseSurveyTable;
+    /**
+     * DDB table that gets the list of all survey tables for a given study. Naming note: This is a DDB table containing
+     * references to a set of Synapse tables. The name is a bit confusing,  but I'm not sure how to make it less
+     * confusing.
+     */
+    @Resource(name = "ddbSynapseSurveyTablesTable")
+    public final void setDdbSynapseSurveyTablesTable(Table ddbSynapseSurveyTablesTable) {
+        this.ddbSynapseSurveyTablesTable = ddbSynapseSurveyTablesTable;
     }
 
     /** Upload schema table. */
@@ -102,7 +106,7 @@ public class DynamoHelper {
      * @return set of survey table IDs, may be empty, but will never be null
      */
     public Set<String> getSynapseSurveyTablesForStudy(String studyId) {
-        Item item = ddbSynapseSurveyTable.getItem("studyId", studyId);
+        Item item = ddbSynapseSurveyTablesTable.getItem("studyId", studyId);
         if (item == null) {
             return ImmutableSet.of();
         }

--- a/src/main/java/org/sagebionetworks/bridge/udd/dynamodb/DynamoHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/dynamodb/DynamoHelper.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Resource;
 
 import com.amazonaws.services.dynamodbv2.document.Index;
@@ -12,6 +13,7 @@ import com.amazonaws.services.dynamodbv2.document.Item;
 import com.amazonaws.services.dynamodbv2.document.RangeKeyCondition;
 import com.amazonaws.services.dynamodbv2.document.Table;
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import org.springframework.stereotype.Component;
 
@@ -21,6 +23,7 @@ public class DynamoHelper {
     private Table ddbHealthIdTable;
     private Table ddbStudyTable;
     private Table ddbSynapseMapTable;
+    private Table ddbSynapseSurveyTable;
     private Table ddbUploadSchemaTable;
     private Index ddbUploadSchemaStudyIndex;
 
@@ -40,6 +43,12 @@ public class DynamoHelper {
     @Resource(name = "ddbSynapseMapTable")
     public final void setDdbSynapseMapTable(Table ddbSynapseMapTable) {
         this.ddbSynapseMapTable = ddbSynapseMapTable;
+    }
+
+    /** DDB table that gets the list of all survey tables for a given study. */
+    @Resource(name = "ddbSynapseSurveyTable")
+    public final void setDdbSynapseSurveyTable(Table ddbSynapseSurveyTable) {
+        this.ddbSynapseSurveyTable = ddbSynapseSurveyTable;
     }
 
     /** Upload schema table. */
@@ -86,12 +95,33 @@ public class DynamoHelper {
     }
 
     /**
+     * Gets the set of survey table IDs for a given study.
+     *
+     * @param studyId
+     *         ID of study to get survey tables
+     * @return set of survey table IDs, may be empty, but will never be null
+     */
+    public Set<String> getSynapseSurveyTablesForStudy(String studyId) {
+        Item item = ddbSynapseSurveyTable.getItem("studyId", studyId);
+        if (item == null) {
+            return ImmutableSet.of();
+        }
+
+        Set<String> tableIdSet = item.getStringSet("tableIdSet");
+        if (tableIdSet == null) {
+            return ImmutableSet.of();
+        }
+
+        return tableIdSet;
+    }
+
+    /**
      * Gets the Synapse table IDs associated with this study. The results are returned as a map from the Synapse table
      * IDs to the Bridge upload schemas.
      *
      * @param studyId
      *         ID of the study to query on
-     * @return map from the Synapse table IDs to the Bridge upload schema keys
+     * @return map from the Synapse table IDs to the Bridge upload schema keys, may be empty, but will never be null
      */
     public Map<String, UploadSchema> getSynapseTableIdsForStudy(String studyId) throws IOException {
         // query and iterate

--- a/src/main/java/org/sagebionetworks/bridge/udd/helper/FileHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/helper/FileHelper.java
@@ -14,6 +14,8 @@ import java.io.OutputStreamWriter;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /**
@@ -22,6 +24,8 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class FileHelper {
+    private static final Logger LOG = LoggerFactory.getLogger(FileHelper.class);
+
     //
     // The following methods should be mocked, as they represent primitive operations to the file system.
     //
@@ -58,18 +62,18 @@ public class FileHelper {
      * Delete the specified directory. This is used so that mock file systems can keep track of files. Even though
      * this is identical to deleteFile(), having a separate deleteDir() makes mocking and testing easier.
      */
-    public void deleteDir(File dir) throws IOException {
+    public void deleteDir(File dir) {
         boolean success = dir.delete();
         if (!success) {
-            throw new IOException("Failed to delete directory: " + dir.getName());
+            LOG.error("Failed to delete directory: " + dir.getAbsolutePath());
         }
     }
 
     /** Delete the specified file. This is used so that mock file systems can keep track of files. */
-    public void deleteFile(File file) throws IOException {
+    public void deleteFile(File file) {
         boolean success = file.delete();
         if (!success) {
-            throw new IOException("Failed to delete file: " + file.getName());
+            LOG.error("Failed to delete file: " + file.getAbsolutePath());
         }
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadFromTableTask.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadFromTableTask.java
@@ -395,12 +395,7 @@ public class SynapseDownloadFromTableTask implements Callable<SynapseDownloadFro
                 // No file. No need to cleanup.
                 continue;
             }
-
-            try {
-                fileHelper.deleteFile(oneFileToDelete);
-            } catch (IOException ex) {
-                LOG.error("Error deleting file " + oneFileToDelete.getAbsolutePath());
-            }
+            fileHelper.deleteFile(oneFileToDelete);
         }
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadSurveyParameters.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadSurveyParameters.java
@@ -1,0 +1,57 @@
+package org.sagebionetworks.bridge.udd.synapse;
+
+import java.io.File;
+
+import com.google.common.base.Strings;
+
+/** Params needed to execute the SynapseDownloadSurveyTask. */
+public class SynapseDownloadSurveyParameters {
+    private final String synapseTableId;
+    private final File tempDir;
+
+    /** Private constructor. To build, use builder. */
+    private SynapseDownloadSurveyParameters(String synapseTableId, File tempDir) {
+        this.synapseTableId = synapseTableId;
+        this.tempDir = tempDir;
+    }
+
+    /** ID of the Synapse table with the survey metadata. */
+    public String getSynapseTableId() {
+        return synapseTableId;
+    }
+
+    /** Temp dir to download the survey metadata to.. */
+    public File getTempDir() {
+        return tempDir;
+    }
+
+    /** Parameter class builder. */
+    public static class Builder {
+        private String synapseTableId;
+        private File tempDir;
+
+        /** @see SynapseDownloadSurveyParameters#getSynapseTableId */
+        public Builder withSynapseTableId(String synapseTableId) {
+            this.synapseTableId = synapseTableId;
+            return this;
+        }
+        /** @see SynapseDownloadSurveyParameters#getTempDir */
+        public Builder withTempDir(File tempDir) {
+            this.tempDir = tempDir;
+            return this;
+        }
+
+        /** Builds the parameters object and validates parameters. */
+        public SynapseDownloadSurveyParameters build() {
+            if (Strings.isNullOrEmpty(synapseTableId)) {
+                throw new IllegalStateException("synapseTableId must be specified");
+            }
+
+            if (tempDir == null) {
+                throw new IllegalStateException("tempDir must be specified");
+            }
+
+            return new SynapseDownloadSurveyParameters(synapseTableId, tempDir);
+        }
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadSurveyTask.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadSurveyTask.java
@@ -1,0 +1,100 @@
+package org.sagebionetworks.bridge.udd.synapse;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.base.Stopwatch;
+import org.sagebionetworks.client.exceptions.SynapseException;
+import org.sagebionetworks.repo.model.table.TableEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.sagebionetworks.bridge.udd.exceptions.AsyncTimeoutException;
+import org.sagebionetworks.bridge.udd.helper.FileHelper;
+
+/**
+ * This one-shot asynchronous task downloads a survey metadata table from Synapse. The survey metadata is downloaded in
+ * CSV format.
+ */
+public class SynapseDownloadSurveyTask implements Callable<File> {
+    private static final Logger LOG = LoggerFactory.getLogger(SynapseDownloadSurveyTask.class);
+
+    // Task parameters. Params is passed in by constructor.
+    private final SynapseDownloadSurveyParameters params;
+
+    // Helpers and config objects. Originates from Spring configs and is passed in through setters using a similar
+    // pattern.
+    private FileHelper fileHelper;
+    private SynapseHelper synapseHelper;
+
+    /**
+     * Constructs this task with the specified task parameters
+     *
+     * @param params
+     *         task parameters
+     */
+    public SynapseDownloadSurveyTask(SynapseDownloadSurveyParameters params) {
+        this.params = params;
+    }
+
+    /**
+     * Wrapper class around the file system. Used by unit tests to test the functionality without hitting the real file
+     * system.
+     */
+    public final void setFileHelper(FileHelper fileHelper) {
+        this.fileHelper = fileHelper;
+    }
+
+    /** Synapse helper, used to download survey metadata from Synapse. */
+    public final void setSynapseHelper(SynapseHelper synapseHelper) {
+        this.synapseHelper = synapseHelper;
+    }
+
+    /**
+     * Executes this task. Downloads the survey metadata from the Synapse table specified in the params.
+     *
+     * @return the file containing the survey metadata in CSV format, never null
+     */
+    @Override
+    public File call() throws AsyncTimeoutException, SynapseException {
+        String synapseTableId = params.getSynapseTableId();
+
+        // get table name
+        TableEntity table = synapseHelper.getTable(synapseTableId);
+
+        // download table
+        File surveyFile = fileHelper.newFile(params.getTempDir(), table.getName() + ".csv");
+        String surveyFilePath = surveyFile.getAbsolutePath();
+        Stopwatch downloadSurveyStopwatch = Stopwatch.createStarted();
+        try {
+            // We want the whole survey table.
+            String query = "SELECT * FROM " + synapseTableId;
+            String fileHandleId = synapseHelper.generateFileHandleFromTableQuery(query, synapseTableId);
+            synapseHelper.downloadFileHandle(fileHandleId, surveyFile);
+        } catch (AsyncTimeoutException | SynapseException | RuntimeException ex) {
+            // cleanup file (if it were partially started and not finished)
+            if (fileHelper.fileExists(surveyFile)) {
+                try {
+                    fileHelper.deleteFile(surveyFile);
+                } catch (IOException ioEx) {
+                    LOG.error("Error deleting file " + surveyFilePath);
+                }
+            }
+
+            throw ex;
+        } finally {
+            downloadSurveyStopwatch.stop();
+            LOG.info("Downloading survey from table " + synapseTableId + " to file " + surveyFilePath + " took " +
+                    downloadSurveyStopwatch.elapsed(TimeUnit.MILLISECONDS) + " ms");
+        }
+
+        return surveyFile;
+    }
+
+    /** Returns the params. Package-scoped to support tests for {@link SynapsePackager}. */
+    SynapseDownloadSurveyParameters getParameters() {
+        return params;
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadSurveyTask.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadSurveyTask.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.udd.synapse;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -76,11 +75,7 @@ public class SynapseDownloadSurveyTask implements Callable<File> {
         } catch (AsyncTimeoutException | SynapseException | RuntimeException ex) {
             // cleanup file (if it were partially started and not finished)
             if (fileHelper.fileExists(surveyFile)) {
-                try {
-                    fileHelper.deleteFile(surveyFile);
-                } catch (IOException ioEx) {
-                    LOG.error("Error deleting file " + surveyFilePath);
-                }
+                fileHelper.deleteFile(surveyFile);
             }
 
             throw ex;

--- a/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapseHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapseHelper.java
@@ -14,6 +14,7 @@ import org.sagebionetworks.repo.model.file.BulkFileDownloadResponse;
 import org.sagebionetworks.repo.model.file.FileHandleAssociateType;
 import org.sagebionetworks.repo.model.file.FileHandleAssociation;
 import org.sagebionetworks.repo.model.table.DownloadFromTableResult;
+import org.sagebionetworks.repo.model.table.TableEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -124,6 +125,20 @@ public class SynapseHelper {
         DownloadFromTableResult result = pollAsync(() ->
                 synapseClient.downloadCsvFromTableAsyncGet(asyncJobToken, synapseTableId));
         return result.getResultsFileHandleId();
+    }
+
+    /**
+     * Convenience method to get a table entity. This exists mainly so all Synapse calls go through the helper, instead
+     * of forcing callers to sometimes use the helper and sometimes use the client. This also enables retry logic.
+     *
+     * @param tableId
+     *         ID of table to fetch
+     * @return table entity
+     * @throws SynapseException
+     *         if the Synapse call fails
+     */
+    public TableEntity getTable(String tableId) throws SynapseException {
+        return synapseClient.getEntity(tableId, TableEntity.class);
     }
 
     /**

--- a/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapsePackager.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapsePackager.java
@@ -7,6 +7,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -45,6 +46,7 @@ public class SynapsePackager {
     static final String CONFIG_KEY_EXPIRATION_HOURS = "s3.url.expiration.hours";
     static final String CONFIG_KEY_USERDATA_BUCKET = "userdata.bucket";
     static final String ERROR_LOG_FILE_NAME = "error.log";
+    static final String METADATA_ERROR_LOG_FILE_NAME = "metadata-error.log";
 
     private static final Joiner LINE_JOINER = Joiner.on('\n');
 
@@ -99,7 +101,12 @@ public class SynapsePackager {
     }
 
     /**
+     * <p>
      * Downloads data from Synapse tables, uploads them to S3, and generates a pre-signed URL for the data.
+     * </p>
+     * <p>
+     * Schema map and survey table ID set are guaranteed by the DynamoHelper to be non-null.
+     * </p>
      *
      * @param synapseToSchemaMap
      *         map from Synapse table IDs to schemas, used to enumerate Synapse tables and determine file names
@@ -107,20 +114,30 @@ public class SynapsePackager {
      *         user health code to filter on
      * @param request
      *         user data download request, used to determine start and end dates for requested data
+     * @param surveyTableIdSet
+     *         set of survey table IDs, which need to be downloaded in their entirety
      * @return pre-signed URL and expiration time
      */
     public PresignedUrlInfo packageSynapseData(Map<String, UploadSchema> synapseToSchemaMap, String healthCode,
-            BridgeUddRequest request) throws IOException {
-        List<File> allFileList = null;
+            BridgeUddRequest request, Set<String> surveyTableIdSet) throws IOException {
+        List<File> allFileList = new ArrayList<>();
         File masterZipFile = null;
         File tmpDir = fileHelper.createTempDir();
         try {
             // create and execute Synapse downloads asynchronously
-            List<Future<SynapseDownloadFromTableResult>> taskFutureList = initAsyncTasks(synapseToSchemaMap,
+            List<Future<SynapseDownloadFromTableResult>> queryFutureList = initAsyncQueryTasks(synapseToSchemaMap,
                     healthCode, request, tmpDir);
-            allFileList = waitForAsyncTasks(tmpDir, taskFutureList);
+            List<Future<File>> surveyFutureList = initAsyncSurveyTasks(surveyTableIdSet, tmpDir);
 
-            if (allFileList.isEmpty()) {
+            // wait for async tasks - We need to wait for all tasks and gather up all files before we check whether we
+            // have no query results. Otherwise, we won't know to clean up these files, and we'll leave garbage on our
+            // file system.
+            List<File> queryFileList = waitForAsyncQueryTasks(tmpDir, queryFutureList);
+            allFileList.addAll(queryFileList);
+            List<File> surveyFileList = waitForAsyncSurveyTasks(tmpDir, surveyFutureList);
+            allFileList.addAll(surveyFileList);
+
+            if (queryFileList.isEmpty()) {
                 // There are no files to send, meaning there is no user data to send. Return null, to signal that there
                 // is no pre-signed URL to send.
                 return null;
@@ -159,7 +176,7 @@ public class SynapsePackager {
      *         temp directory that files should be downloaded to
      * @return list of Futures for the async tasks
      */
-    List<Future<SynapseDownloadFromTableResult>> initAsyncTasks(Map<String, UploadSchema> synapseToSchemaMap,
+    List<Future<SynapseDownloadFromTableResult>> initAsyncQueryTasks(Map<String, UploadSchema> synapseToSchemaMap,
             String healthCode, BridgeUddRequest request, File tmpDir) {
         List<Future<SynapseDownloadFromTableResult>> taskFutureList = new ArrayList<>();
         for (Map.Entry<String, UploadSchema> oneSynapseToSchemaEntry : synapseToSchemaMap.entrySet()) {
@@ -183,6 +200,33 @@ public class SynapsePackager {
     }
 
     /**
+     * Kicks off async tasks to download survey metadata from Synapse.
+     *
+     * @param surveyTableIdSet
+     *         set of survey metadata table IDs to download
+     * @param tmpDir
+     *         temp dir to download tables to
+     * @return list of Futures for the async tasks
+     */
+    private List<Future<File>> initAsyncSurveyTasks(Set<String> surveyTableIdSet, File tmpDir) {
+        List<Future<File>> futureList = new ArrayList<>();
+        for (String oneTableId : surveyTableIdSet) {
+            // create params
+            SynapseDownloadSurveyParameters param = new SynapseDownloadSurveyParameters.Builder()
+                    .withSynapseTableId(oneTableId).withTempDir(tmpDir).build();
+
+            // kick off async task
+            SynapseDownloadSurveyTask task = new SynapseDownloadSurveyTask(param);
+            task.setFileHelper(fileHelper);
+            task.setSynapseHelper(synapseHelper);
+            Future<File> future = auxiliaryExecutorService.submit(task);
+            futureList.add(future);
+        }
+
+        return futureList;
+    }
+
+    /**
      * Waits on the async tasks, then gathers up all the files downloaded. This also writes a log with error messages
      * for each failed async task.
      *
@@ -194,7 +238,7 @@ public class SynapsePackager {
      * @throws IOException
      *         if writing the error log fails
      */
-    private List<File> waitForAsyncTasks(File tmpDir, List<Future<SynapseDownloadFromTableResult>> taskFutureList)
+    private List<File> waitForAsyncQueryTasks(File tmpDir, List<Future<SynapseDownloadFromTableResult>> taskFutureList)
             throws IOException {
         // join on threads until they're all done
         List<File> allFileList = new ArrayList<>();
@@ -219,16 +263,69 @@ public class SynapsePackager {
 
         // write errors into an error log file for the user
         if (!errorList.isEmpty()) {
-            String errorLog = LINE_JOINER.join(errorList);
-            File errorLogFile = fileHelper.newFile(tmpDir, ERROR_LOG_FILE_NAME);
-
-            try (Writer errorLogFileWriter = fileHelper.getWriter(errorLogFile)) {
-                errorLogFileWriter.write(errorLog);
-            }
-
+            File errorLogFile = writeErrorLog(errorList, ERROR_LOG_FILE_NAME, tmpDir);
             allFileList.add(errorLogFile);
         }
         return allFileList;
+    }
+
+    /**
+     * Waits for the survey metadata async tasks. Returns a list of the downloaded metadata files. The list also
+     * includes an error log, if there are any errors.
+     *
+     * @param tmpDir
+     *         temp directory files should be downloaded to and error log should be written to
+     * @param futureList
+     *         list of Futures for async tasks that should be waited on
+     * @return list of all files downloaded, plus error log
+     * @throws IOException
+     *         if writing the error log fails
+     */
+    private List<File> waitForAsyncSurveyTasks(File tmpDir, List<Future<File>> futureList) throws IOException {
+        // join on threads until they're all done
+        List<File> fileList = new ArrayList<>();
+        List<String> errorList = new ArrayList<>();
+        for (Future<File> oneFuture : futureList) {
+            try {
+                File file = oneFuture.get();
+                fileList.add(file);
+            } catch (ExecutionException | InterruptedException ex) {
+                String errorMsg = "Error downloading survey: " + ex.getMessage();
+                LOG.error(errorMsg, ex);
+                errorList.add(errorMsg);
+            }
+        }
+
+        // write errors into an error log file for the user
+        if (!errorList.isEmpty()) {
+            File errorLogFile = writeErrorLog(errorList, METADATA_ERROR_LOG_FILE_NAME, tmpDir);
+            fileList.add(errorLogFile);
+        }
+        return fileList;
+    }
+
+    /**
+     * Given a list of error messages, a file name, and a directory to write to, this creates the error log with those
+     * error messages. This is generally used for packaging an error log to send to users, so they know if their
+     * request is successful and what went wrong. (And they can send the error log back to use for diagnosis.)
+     *
+     * @param errorList
+     *         list of error messages
+     * @param filename
+     *         file name of error log to write to
+     * @param parentDir
+     *         parent dir of error log file
+     * @return error log file
+     * @throws IOException
+     *         if creating or writing to the error log file fails
+     */
+    private File writeErrorLog(List<String> errorList, String filename, File parentDir) throws IOException {
+        String errorLog = LINE_JOINER.join(errorList);
+        File errorLogFile = fileHelper.newFile(parentDir, filename);
+        try (Writer errorLogFileWriter = fileHelper.getWriter(errorLogFile)) {
+            errorLogFileWriter.write(errorLog);
+        }
+        return errorLogFile;
     }
 
     /**

--- a/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapsePackager.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapsePackager.java
@@ -258,6 +258,11 @@ public class SynapsePackager {
                 String errorMsg = "Error downloading CSV: " + ex.getMessage();
                 LOG.error(errorMsg, ex);
                 errorList.add(errorMsg);
+
+                // Thread bookkeeping. Might be relevant in the future.
+                if (ex instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
             }
         }
 
@@ -293,6 +298,11 @@ public class SynapsePackager {
                 String errorMsg = "Error downloading survey: " + ex.getMessage();
                 LOG.error(errorMsg, ex);
                 errorList.add(errorMsg);
+
+                // Thread bookkeeping. Might be relevant in the future.
+                if (ex instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
             }
         }
 
@@ -410,19 +420,10 @@ public class SynapsePackager {
                 // No file. No need to cleanup.
                 continue;
             }
-
-            try {
-                fileHelper.deleteFile(oneFileToDelete);
-            } catch (IOException ex) {
-                LOG.error("Error deleting file " + oneFileToDelete.getAbsolutePath());
-            }
+            fileHelper.deleteFile(oneFileToDelete);
         }
 
         // clean up temp dir
-        try {
-            fileHelper.deleteDir(tmpDir);
-        } catch (IOException ex) {
-            LOG.error("Error deleting temp dir " + tmpDir.getAbsolutePath());
-        }
+        fileHelper.deleteDir(tmpDir);
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/udd/worker/BridgeUddWorker.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/worker/BridgeUddWorker.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.udd.worker;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import com.amazonaws.services.sqs.model.Message;
@@ -127,8 +128,9 @@ public class BridgeUddWorker implements Runnable {
                     AccountInfo accountInfo = stormpathHelper.getAccount(studyInfo, username);
                     String healthCode = dynamoHelper.getHealthCodeFromHealthId(accountInfo.getHealthId());
                     Map<String, UploadSchema> synapseToSchemaMap = dynamoHelper.getSynapseTableIdsForStudy(studyId);
+                    Set<String> surveyTableIdSet = dynamoHelper.getSynapseSurveyTablesForStudy(studyId);
                     PresignedUrlInfo presignedUrlInfo = synapsePackager.packageSynapseData(synapseToSchemaMap,
-                            healthCode, request);
+                            healthCode, request, surveyTableIdSet);
 
                     if (presignedUrlInfo == null) {
                         LOG.info("No data for request for hash[username]=" + userHash + ", study=" + studyId +

--- a/src/test/java/org/sagebionetworks/bridge/udd/dynamodb/DynamoHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/dynamodb/DynamoHelperTest.java
@@ -70,7 +70,7 @@ public class DynamoHelperTest {
 
         // set up dynamo helper
         DynamoHelper helper = new DynamoHelper();
-        helper.setDdbSynapseSurveyTable(mockSynapseSurveyTable);
+        helper.setDdbSynapseSurveyTablesTable(mockSynapseSurveyTable);
 
         // execute and validate
         Set<String> tableIdSet = helper.getSynapseSurveyTablesForStudy("test-study");
@@ -88,7 +88,7 @@ public class DynamoHelperTest {
 
         // set up dynamo helper
         DynamoHelper helper = new DynamoHelper();
-        helper.setDdbSynapseSurveyTable(mockSynapseSurveyTable);
+        helper.setDdbSynapseSurveyTablesTable(mockSynapseSurveyTable);
 
         // execute and validate
         Set<String> tableIdSet = helper.getSynapseSurveyTablesForStudy("test-study");
@@ -103,7 +103,7 @@ public class DynamoHelperTest {
 
         // set up dynamo helper
         DynamoHelper helper = new DynamoHelper();
-        helper.setDdbSynapseSurveyTable(mockSynapseSurveyTable);
+        helper.setDdbSynapseSurveyTablesTable(mockSynapseSurveyTable);
 
         // execute and validate
         Set<String> tableIdSet = helper.getSynapseSurveyTablesForStudy("test-study");

--- a/src/test/java/org/sagebionetworks/bridge/udd/dynamodb/DynamoHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/dynamodb/DynamoHelperTest.java
@@ -5,10 +5,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.amazonaws.services.dynamodbv2.document.Index;
 import com.amazonaws.services.dynamodbv2.document.Item;
@@ -56,6 +58,56 @@ public class DynamoHelperTest {
         assertEquals(studyInfo.getName(), "Test Study");
         assertEquals(studyInfo.getStormpathHref(), "dummy-stormpath-href");
         assertEquals(studyInfo.getSupportEmail(), "support@sagebase.org");
+    }
+
+    @Test
+    public void testGetSynapseSurveyTables() {
+        // mock Synapse survey table
+        Item mockItem = new Item().withString("studyId", "test-study").withStringSet("tableIdSet", "foo-table",
+                "bar-table");
+        Table mockSynapseSurveyTable = mock(Table.class);
+        when(mockSynapseSurveyTable.getItem("studyId", "test-study")).thenReturn(mockItem);
+
+        // set up dynamo helper
+        DynamoHelper helper = new DynamoHelper();
+        helper.setDdbSynapseSurveyTable(mockSynapseSurveyTable);
+
+        // execute and validate
+        Set<String> tableIdSet = helper.getSynapseSurveyTablesForStudy("test-study");
+        assertEquals(tableIdSet.size(), 2);
+        assertTrue(tableIdSet.contains("foo-table"));
+        assertTrue(tableIdSet.contains("bar-table"));
+    }
+
+    @Test
+    public void testGetSynapseSurveyTablesNoTableIds() {
+        // mock Synapse survey table
+        Item mockItem = new Item().withString("studyId", "test-study");
+        Table mockSynapseSurveyTable = mock(Table.class);
+        when(mockSynapseSurveyTable.getItem("studyId", "test-study")).thenReturn(mockItem);
+
+        // set up dynamo helper
+        DynamoHelper helper = new DynamoHelper();
+        helper.setDdbSynapseSurveyTable(mockSynapseSurveyTable);
+
+        // execute and validate
+        Set<String> tableIdSet = helper.getSynapseSurveyTablesForStudy("test-study");
+        assertTrue(tableIdSet.isEmpty());
+    }
+
+    @Test
+    public void testGetSynapseSurveyTablesNoItem() {
+        // mock Synapse survey table
+        Table mockSynapseSurveyTable = mock(Table.class);
+        when(mockSynapseSurveyTable.getItem("studyId", "test-study")).thenReturn(null);
+
+        // set up dynamo helper
+        DynamoHelper helper = new DynamoHelper();
+        helper.setDdbSynapseSurveyTable(mockSynapseSurveyTable);
+
+        // execute and validate
+        Set<String> tableIdSet = helper.getSynapseSurveyTablesForStudy("test-study");
+        assertTrue(tableIdSet.isEmpty());
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/udd/helper/InMemoryFileHelper.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/helper/InMemoryFileHelper.java
@@ -66,20 +66,24 @@ public class InMemoryFileHelper extends FileHelper {
 
     // DELETE
 
+    // Throws IllegalArgumentException because even though the prod method logs exceptions and swallows them, we want
+    // our tests to fail if we try to delete a non-existent file.
     @Override
-    public void deleteDir(File dir) throws FileNotFoundException {
+    public void deleteDir(File dir) {
         String dirPath = dir.getAbsolutePath();
         if (!dirSet.contains(dirPath)) {
-            throw new FileNotFoundException("Can't deleted dir " + dirPath + ": dir doesn't exist");
+            throw new IllegalArgumentException("Can't deleted dir " + dirPath + ": dir doesn't exist");
         }
         dirSet.remove(dirPath);
     }
 
+    // Throws IllegalArgumentException because even though the prod method logs exceptions and swallows them, we want
+    // our tests to fail if we try to delete a non-existent file.
     @Override
-    public void deleteFile(File file) throws FileNotFoundException {
+    public void deleteFile(File file) {
         String filePath = file.getAbsolutePath();
         if (!fileMap.containsKey(filePath)) {
-            throw new FileNotFoundException("Can't delete file " + filePath + ": file doesn't exist");
+            throw new IllegalArgumentException("Can't delete file " + filePath + ": file doesn't exist");
         }
         fileMap.remove(filePath);
     }

--- a/src/test/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadSurveyParametersTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadSurveyParametersTest.java
@@ -1,0 +1,35 @@
+package org.sagebionetworks.bridge.udd.synapse;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+
+import java.io.File;
+
+import org.testng.annotations.Test;
+
+public class SynapseDownloadSurveyParametersTest {
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*synapseTableId.*")
+    public void nullTableId() {
+        new SynapseDownloadSurveyParameters.Builder().withTempDir(mock(File.class)).build();
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*synapseTableId.*")
+    public void emptyTableId() {
+        new SynapseDownloadSurveyParameters.Builder().withSynapseTableId("").withTempDir(mock(File.class)).build();
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*tempDir.*")
+    public void nullTempDir() {
+        new SynapseDownloadSurveyParameters.Builder().withSynapseTableId("test-table").build();
+    }
+
+    @Test
+    public void happyCase() {
+        File mockFile = mock(File.class);
+        SynapseDownloadSurveyParameters params = new SynapseDownloadSurveyParameters.Builder()
+                .withSynapseTableId("test-table").withTempDir(mockFile).build();
+        assertEquals(params.getSynapseTableId(), "test-table");
+        assertSame(params.getTempDir(), mockFile);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadSurveyTaskTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadSurveyTaskTest.java
@@ -1,0 +1,136 @@
+package org.sagebionetworks.bridge.udd.synapse;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.io.File;
+import java.io.Reader;
+import java.io.Writer;
+
+import com.google.common.io.CharStreams;
+import org.sagebionetworks.client.exceptions.SynapseException;
+import org.sagebionetworks.repo.model.table.TableEntity;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.udd.helper.InMemoryFileHelper;
+
+public class SynapseDownloadSurveyTaskTest {
+    private static final String TEST_FILE_HANDLE = "test-file-handle";
+    private static final String TEST_SYNAPSE_TABLE_ID = "test-table";
+    private static final String TEST_SYNAPSE_TABLE_NAME = "Test Table";
+
+    private InMemoryFileHelper fileHelper;
+    private SynapseHelper synapseHelper;
+    private SynapseDownloadSurveyTask task;
+    private File tmpDir;
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        // mock Synapse helper
+        synapseHelper = mock(SynapseHelper.class);
+
+        TableEntity table = new TableEntity();
+        table.setId(TEST_SYNAPSE_TABLE_ID);
+        table.setName(TEST_SYNAPSE_TABLE_NAME);
+        when(synapseHelper.getTable(TEST_SYNAPSE_TABLE_ID)).thenReturn(table);
+
+        when(synapseHelper.generateFileHandleFromTableQuery("SELECT * FROM " + TEST_SYNAPSE_TABLE_ID,
+                TEST_SYNAPSE_TABLE_ID)).thenReturn(TEST_FILE_HANDLE);
+
+        // create in-memory file helper
+        fileHelper = new InMemoryFileHelper();
+        tmpDir = fileHelper.createTempDir();
+
+        // create params
+        SynapseDownloadSurveyParameters params = new SynapseDownloadSurveyParameters.Builder()
+                .withSynapseTableId(TEST_SYNAPSE_TABLE_ID).withTempDir(tmpDir).build();
+
+        // create task
+        task = new SynapseDownloadSurveyTask(params);
+        task.setFileHelper(fileHelper);
+        task.setSynapseHelper(synapseHelper);
+    }
+
+    @Test
+    public void errorDownloadingFile() throws Exception {
+        // set up error
+        doThrow(new TestSynapseException()).when(synapseHelper).downloadFileHandle(eq(TEST_FILE_HANDLE),
+                notNull(File.class));
+
+        // execute
+        Exception thrownEx = null;
+        try {
+            task.call();
+            fail("expected exception");
+        } catch (SynapseException ex) {
+            thrownEx = ex;
+        }
+        assertNotNull(thrownEx);
+
+        postValidation();
+    }
+
+    @Test
+    public void errorPartialDownload() throws Exception {
+        // set up error
+        doAnswer(invocation -> {
+            File targetFile = invocation.getArgumentAt(1, File.class);
+            try (Writer targetFileWriter = fileHelper.getWriter(targetFile)) {
+                targetFileWriter.write("partial survey content");
+            }
+
+            throw new TestSynapseException();
+        }).when(synapseHelper).downloadFileHandle(eq(TEST_FILE_HANDLE), notNull(File.class));
+
+        // execute
+        Exception thrownEx = null;
+        try {
+            task.call();
+            fail("expected exception");
+        } catch (SynapseException ex) {
+            thrownEx = ex;
+        }
+        assertNotNull(thrownEx);
+
+        postValidation();
+    }
+
+    @Test
+    public void happyCase() throws Exception {
+        // set up Synapse helper
+        doAnswer(invocation -> {
+            File targetFile = invocation.getArgumentAt(1, File.class);
+            try (Writer targetFileWriter = fileHelper.getWriter(targetFile)) {
+                targetFileWriter.write("dummy survey content");
+            }
+
+            // Answer declares return type, even if Void
+            return null;
+        }).when(synapseHelper).downloadFileHandle(eq(TEST_FILE_HANDLE), notNull(File.class));
+
+        // execute and validate
+        File file = task.call();
+        try (Reader reader = fileHelper.getReader(file)) {
+            assertEquals(CharStreams.toString(reader), "dummy survey content");
+        }
+
+        // cleanup/post-validation
+        fileHelper.deleteFile(file);
+        postValidation();
+    }
+
+    // We can't use an AfterMethod, because AfterMethod doesn't report which method failed.
+    private void postValidation() throws Exception {
+        fileHelper.deleteDir(tmpDir);
+        assertTrue(fileHelper.isEmpty());
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/udd/synapse/SynapseHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/synapse/SynapseHelperTest.java
@@ -2,10 +2,13 @@ package org.sagebionetworks.bridge.udd.synapse;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertSame;
 
 import java.io.File;
 
 import org.sagebionetworks.client.SynapseClient;
+import org.sagebionetworks.repo.model.table.TableEntity;
 import org.testng.annotations.Test;
 
 public class SynapseHelperTest {
@@ -23,5 +26,22 @@ public class SynapseHelperTest {
         helper.downloadFileHandle("test-file-handle", mockTargetFile);
 
         verify(mockClient).downloadFromFileHandleTemporaryUrl("test-file-handle", mockTargetFile);
+    }
+
+    @Test
+    public void getTable() throws Exception {
+        // This is a pass through. Just test that we pass through the args correctly.
+
+        // mock client
+        SynapseClient mockClient = mock(SynapseClient.class);
+        TableEntity mockTable = new TableEntity();
+        when(mockClient.getEntity("test-table", TableEntity.class)).thenReturn(mockTable);
+
+        SynapseHelper helper = new SynapseHelper();
+        helper.setSynapseClient(mockClient);
+
+        // execute and validate
+        TableEntity retval = helper.getTable("test-table");
+        assertSame(retval, mockTable);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/udd/worker/BridgeUddWorkerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/worker/BridgeUddWorkerTest.java
@@ -11,9 +11,11 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.fail;
 
 import java.util.Map;
+import java.util.Set;
 
 import com.amazonaws.services.sqs.model.Message;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.config.Config;
@@ -39,6 +41,7 @@ public class BridgeUddWorkerTest {
         // of instantiating all the fields.
         StudyInfo mockStudyInfo = mock(StudyInfo.class);
         Map<String, UploadSchema> mockSynapseToSchema = ImmutableMap.of();
+        Set<String> mockSurveyTableIdSet = ImmutableSet.of();
         PresignedUrlInfo mockPresignedUrlInfo = mock(PresignedUrlInfo.class);
 
         // non-mock test objects - We break inside these objects to get data.
@@ -74,6 +77,7 @@ public class BridgeUddWorkerTest {
         when(mockDynamoHelper.getStudy("test-study")).thenReturn(mockStudyInfo);
         when(mockDynamoHelper.getHealthCodeFromHealthId("test-health-id")).thenReturn("test-health-code");
         when(mockDynamoHelper.getSynapseTableIdsForStudy("test-study")).thenReturn(mockSynapseToSchema);
+        when(mockDynamoHelper.getSynapseSurveyTablesForStudy("test-study")).thenReturn(mockSurveyTableIdSet);
 
         // mock stormpath helper
         StormpathHelper mockStormpathHelper = mock(StormpathHelper.class);
@@ -82,7 +86,7 @@ public class BridgeUddWorkerTest {
         // mock Synapse packager
         SynapsePackager mockPackager = mock(SynapsePackager.class);
         when(mockPackager.packageSynapseData(same(mockSynapseToSchema), eq("test-health-code"),
-                any(BridgeUddRequest.class))).thenAnswer(invocation -> {
+                any(BridgeUddRequest.class), same(mockSurveyTableIdSet))).thenAnswer(invocation -> {
             // Second request is in March, that has no data. Third request is in August, that has data.
             BridgeUddRequest request = invocation.getArgumentAt(2, BridgeUddRequest.class);
             int startMonth = request.getStartDate().getMonthOfYear();


### PR DESCRIPTION
This adds another Synapse async task to download survey metadata tables. Survey metadata tables are currently created manually, based on JSON sent in from the client app developers. An entry is stored in DDB, which maps the study ID to the set of survey metadata table IDs.

Testing done:
- mvn verify (unit tests, find-bugs, jacoco coverage checks)
- manual tests
