### PR TITLE
set up Logentries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .idea
 *.iml
 target

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,12 @@
             <version>18.0</version>
         </dependency>
         <dependency>
+            <groupId>com.logentries</groupId>
+            <artifactId>logentries-appender</artifactId>
+            <version>RELEASE</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>com.stormpath.sdk</groupId>
             <artifactId>stormpath-sdk-api</artifactId>
             <version>${stormpath.version}</version>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -6,8 +6,20 @@
         </encoder>
     </appender>
 
+    <!-- To test this locally, run mvn spring-boot:run -Dlogentries.token=[token] -->
+    <appender name="LOGENTRIES" class="com.logentries.logback.LogentriesAppender">
+        <Debug>False</Debug>
+        <Token>${logentries.token}</Token>
+        <Ssl>False</Ssl>
+        <facility>USER</facility>
+        <layout>
+            <pattern>%d{ISO8601} %-5p [%t] %logger - %message%n%xException%n%mdc</pattern>
+        </layout>
+    </appender>
+
     <root level="WARN">
         <appender-ref ref="STDOUT" />
+        <appender-ref ref="LOGENTRIES" />
     </root>
 
     <logger name="org.sagebionetworks.bridge.udd" level="INFO" />


### PR DESCRIPTION
Configured Logentries for Bridge User Data Download Service. This allows us much easier access to the logs. Logentries was chosen because I'm already familiar with it and because it's incredibly simple to set up through Logback.

Testing done:
- tested locally w/o logentries.token, to make sure STDOUT logging still works
- tested locally w/ logentries token
- uploaded test WAR to devo and tested logging on devo

In all test cases, I ran a full request through UDD to make sure it still works and the logs are captured.
