### PR TITLE
Logentries Java Agent config in Bridge-UDD

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,12 +65,6 @@
             <version>0.22.1</version>
         </dependency>
         <dependency>
-            <groupId>com.logentries</groupId>
-            <artifactId>logentries-appender</artifactId>
-            <version>RELEASE</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>com.stormpath.sdk</groupId>
             <artifactId>stormpath-sdk-api</artifactId>
             <version>${stormpath.version}</version>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -6,20 +6,8 @@
         </encoder>
     </appender>
 
-    <!-- To test this locally, run mvn spring-boot:run -Dlogentries.token=[token] -->
-    <appender name="LOGENTRIES" class="com.logentries.logback.LogentriesAppender">
-        <Debug>False</Debug>
-        <Token>${logentries.token}</Token>
-        <Ssl>False</Ssl>
-        <facility>USER</facility>
-        <layout>
-            <pattern>%d{ISO8601} %-5p [%t] %logger - %message%n%xException%n%mdc</pattern>
-        </layout>
-    </appender>
-
     <root level="WARN">
         <appender-ref ref="STDOUT" />
-        <appender-ref ref="LOGENTRIES" />
     </root>
 
     <logger name="org.sagebionetworks.bridge" level="INFO" />

--- a/src/main/webapp/.ebextensions/logentries.config
+++ b/src/main/webapp/.ebextensions/logentries.config
@@ -1,0 +1,39 @@
+option_settings:
+  - option_name: LOGENTRIES_CONFIG_PATH
+    value: /etc/le/config
+
+files:
+  "/etc/yum.repos.d/logentries.repo":
+    mode: "000664"
+    owner: root
+    group: root
+    content: |
+      [logentries]
+      name=Logentries repo
+      enabled=1
+      metadata_expire=1d
+      baseurl=http://rep.logentries.com/amazonlatest/\$basearch
+      gpgkey=http://rep.logentries.com/RPM-GPG-KEY-logentries
+    encoding: plain
+
+commands:
+  01-install-logentries:
+    command: |
+      yum update
+      yum install logentries -y
+      yum install logentries-daemon -y
+
+container_commands:
+  02-create-logentries-config:
+    command: |
+      mkdir -p /etc/le
+      rm -f $LOGENTRIES_CONFIG_PATH
+      echo [Main] > $LOGENTRIES_CONFIG_PATH
+      echo user-key = $LOGENTRIES_USER_KEY >> $LOGENTRIES_CONFIG_PATH
+      echo pull-server-side-config=False >> $LOGENTRIES_CONFIG_PATH
+      echo >> $LOGENTRIES_CONFIG_PATH
+      echo [name] >> $LOGENTRIES_CONFIG_PATH
+      echo path = /var/log/tomcat8/catalina.out >> $LOGENTRIES_CONFIG_PATH
+      echo destination = Bridge-UDD-$ENV/Bridge-UDD-$ENV >> $LOGENTRIES_CONFIG_PATH
+  03-restart-logentries:
+    command: /sbin/service logentries start


### PR DESCRIPTION
Logentries support recommends switching from the Logback Appender to the Java Agent for more robust logging.

Testing done: mvn package to build the war file, deployed it to BridgeUDD-Dev, and verified that logging works.

Tested both on a clean box and on a box that already has Logentries config.
