### PR TITLE
reduce worker threads from 16 to 4

### DIFF
--- a/src/main/resources/BridgeUserDataDownloadService.conf
+++ b/src/main/resources/BridgeUserDataDownloadService.conf
@@ -13,8 +13,11 @@ heartbeat.interval.minutes = 30
 s3.url.expiration.hours = 12
 synapse.poll.interval.millis = 1000
 synapse.poll.max.tries = 300
-threadpool.aux.count = 16
 worker.sleep.time.millis = 125
+
+# As per Synapse team, there are only 4 Synapse workers for running Table queries. As such, there's no point in having
+# more than 4 thread pool workers.
+threadpool.aux.count = 4
 
 local.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-UDD-Request-local
 dev.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-UDD-Request-dev


### PR DESCRIPTION
We're hitting Too Many Concurrent Requests in Synapse. Part of this is because we have a thread pool of 16 to query Synapse tables. However, Synapse only has 4 workers for table queries, so anything above 4 is a waste.

Testing done:
- mvn verify (unit tests, findbugs, jacoco test coverage)
- manual test for basic functionality
