### PR TITLE
Upgrade SynapseJavaClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>BridgeUserDataDownloadService</artifactId>
-    <version>1.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>synapseJavaClient</artifactId>
-            <version>131.0</version>
+            <version>157.0</version>
         </dependency>
 
         <dependency>
@@ -221,10 +221,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
         </plugins>
         <extensions>

--- a/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadFromTableTask.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadFromTableTask.java
@@ -11,13 +11,13 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import au.com.bytecode.opencsv.CSVReader;
 import au.com.bytecode.opencsv.CSVWriter;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.repo.model.file.BulkFileDownloadResponse;
 import org.sagebionetworks.repo.model.file.FileDownloadSummary;
-import org.sagebionetworks.util.csv.CsvNullReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -186,7 +186,7 @@ public class SynapseDownloadFromTableTask implements Callable<SynapseDownloadFro
      * {@link SynapseDownloadFromTableContext#setColumnInfo}.
      */
     private void getColumnInfoFromCsv() throws AsyncTaskExecutionException {
-        try (CsvNullReader csvFileReader = new CsvNullReader(fileHelper.getReader(ctx.getCsvFile()))) {
+        try (CSVReader csvFileReader = new CSVReader(fileHelper.getReader(ctx.getCsvFile()))) {
             // Get first row, the header row. Because of our previous check, we know this row must exist.
             String[] headerRow = csvFileReader.readNext();
 
@@ -221,7 +221,7 @@ public class SynapseDownloadFromTableTask implements Callable<SynapseDownloadFro
         Set<Integer> fileHandleColIdxSet = ctx.getColumnInfo().getFileHandleColumnIndexSet();
 
         Stopwatch extractFileHandlesStopwatch = Stopwatch.createStarted();
-        try (CsvNullReader csvFileReader = new CsvNullReader(fileHelper.getReader(ctx.getCsvFile()))) {
+        try (CSVReader csvFileReader = new CSVReader(fileHelper.getReader(ctx.getCsvFile()))) {
             // Skip header row. We've already processed it.
             csvFileReader.readNext();
 
@@ -324,7 +324,7 @@ public class SynapseDownloadFromTableTask implements Callable<SynapseDownloadFro
         ctx.setEditedCsvFile(editedCsvFile);
 
         Stopwatch editCsvStopwatch = Stopwatch.createStarted();
-        try (CsvNullReader csvFileReader = new CsvNullReader(fileHelper.getReader(ctx.getCsvFile()));
+        try (CSVReader csvFileReader = new CSVReader(fileHelper.getReader(ctx.getCsvFile()));
                 CSVWriter modifiedCsvFileWriter = new CSVWriter(fileHelper.getWriter(editedCsvFile))) {
             // Copy headers.
             modifiedCsvFileWriter.writeNext(csvFileReader.readNext());

--- a/src/test/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadFromTableTaskTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/synapse/SynapseDownloadFromTableTaskTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import au.com.bytecode.opencsv.CSVReader;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharStreams;
@@ -30,7 +31,6 @@ import org.mockito.ArgumentCaptor;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.repo.model.file.BulkFileDownloadResponse;
 import org.sagebionetworks.repo.model.file.FileDownloadSummary;
-import org.sagebionetworks.util.csv.CsvNullReader;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.file.InMemoryFileHelper;
@@ -406,7 +406,7 @@ public class SynapseDownloadFromTableTaskTest {
     // Direct string matching means we tightly couple to the CSV writer implementation. Instead, re-parse the file as a
     // CSV and check the values are what we expect.
     private List<String[]> parseCsv(File csvFile) throws Exception {
-        try (CsvNullReader csvFileReader = new CsvNullReader(inMemoryFileHelper.getReader(csvFile))) {
+        try (CSVReader csvFileReader = new CSVReader(inMemoryFileHelper.getReader(csvFile))) {
             return csvFileReader.readAll();
         }
     }


### PR DESCRIPTION
Older versions of SynapseJavaClient depend on log4j-api-2.0-beta8, which has class AbstractWorkerWrapper, which was removed in log4j-api-2.1. However, some other dependency (possibly a dependency of SynapseJavaClient) is forcing log4j-api-2.1, and we end up in a weird state where some dependencies reference AbstractWorkerWrapper but it's not in the jar.

The fix is to upgrade to a recent version of SynapseJavaClient, which depends on log4j-api-2.6.1 instead, to avoid this version dependency conflict.

Testing done:
* built UDD and WorkerPlatform locally, manually deployed to Elastic Beanstalk, verify that Worker Platform launches properly, and tested both UDD and reporter