### PR TITLE
null check for accounts without health codes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>BridgeUserDataDownloadService</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/org/sagebionetworks/bridge/udd/dynamodb/DynamoHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/dynamodb/DynamoHelper.java
@@ -87,6 +87,9 @@ public class DynamoHelper {
     public String getHealthCodeFromHealthId(String healthId) {
         // convert healthId to healthCode
         Item healthIdItem = ddbHealthIdTable.getItem("id", healthId);
+        if (healthIdItem == null) {
+            return null;
+        }
         return healthIdItem.getString("code");
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/udd/worker/BridgeUddProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/worker/BridgeUddProcessor.java
@@ -80,6 +80,9 @@ public class BridgeUddProcessor {
 
             AccountInfo accountInfo = stormpathHelper.getAccount(studyInfo, username);
             String healthCode = dynamoHelper.getHealthCodeFromHealthId(accountInfo.getHealthId());
+            if (healthCode == null) {
+                throw new PollSqsWorkerBadRequestException("Health code not found for hash[username]=" + userHash);
+            }
             Map<String, UploadSchema> synapseToSchemaMap = dynamoHelper.getSynapseTableIdsForStudy(studyId);
             Set<String> surveyTableIdSet = dynamoHelper.getSynapseSurveyTablesForStudy(studyId);
             PresignedUrlInfo presignedUrlInfo = synapsePackager.packageSynapseData(synapseToSchemaMap,

--- a/src/test/java/org/sagebionetworks/bridge/udd/dynamodb/DynamoHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/dynamodb/DynamoHelperTest.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.udd.dynamodb;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -25,6 +26,20 @@ public class DynamoHelperTest {
             "       \"type\":\"STRING\"\n" +
             "   }\n" +
             "]";
+
+    @Test
+    public void testGetHealthCodeNoCode() {
+        // mock health ID table
+        Table mockHealthIdTable = mock(Table.class);
+        when(mockHealthIdTable.getItem("id", "test-health-id")).thenReturn(null);
+
+        // set up dynamo helper
+        DynamoHelper dynamoHelper = new DynamoHelper();
+        dynamoHelper.setDdbHealthIdTable(mockHealthIdTable);
+
+        // execute and validate
+        assertNull(dynamoHelper.getHealthCodeFromHealthId("test-health-id"));
+    }
 
     @Test
     public void testGetHealthCode() {

--- a/src/test/java/org/sagebionetworks/bridge/udd/worker/BridgeUddProcessorErrorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/worker/BridgeUddProcessorErrorTest.java
@@ -1,0 +1,68 @@
+package org.sagebionetworks.bridge.udd.worker;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.fail;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.json.DefaultObjectMapper;
+import org.sagebionetworks.bridge.sqs.PollSqsWorkerBadRequestException;
+import org.sagebionetworks.bridge.udd.accounts.StormpathHelper;
+import org.sagebionetworks.bridge.udd.dynamodb.DynamoHelper;
+import org.sagebionetworks.bridge.udd.helper.SesHelper;
+import org.sagebionetworks.bridge.udd.synapse.SynapsePackager;
+
+public class BridgeUddProcessorErrorTest {
+    private JsonNode requestJson;
+
+    @BeforeClass
+    public void generalSetup() throws IOException {
+        requestJson = DefaultObjectMapper.INSTANCE.readValue(BridgeUddProcessorTest.REQUEST_JSON_TEXT, JsonNode.class);
+    }
+
+    @Test
+    public void noHealthCode() throws Exception {
+        // mock dynamo helper
+        DynamoHelper mockDynamoHelper = mock(DynamoHelper.class);
+        when(mockDynamoHelper.getStudy(BridgeUddProcessorTest.STUDY_ID)).thenReturn(
+                BridgeUddProcessorTest.MOCK_STUDY_INFO);
+        when(mockDynamoHelper.getHealthCodeFromHealthId(BridgeUddProcessorTest.HEALTH_ID)).thenReturn(null);
+
+        // mock stormpath helper
+        StormpathHelper mockStormpathHelper = mock(StormpathHelper.class);
+        when(mockStormpathHelper.getAccount(same(BridgeUddProcessorTest.MOCK_STUDY_INFO),
+                eq(BridgeUddProcessorTest.EMAIL))).thenReturn(BridgeUddProcessorTest.ACCOUNT_INFO);
+
+        // mock SES helper
+        SesHelper mockSesHelper = mock(SesHelper.class);
+
+        // mock Synapse packager
+        SynapsePackager mockPackager = mock(SynapsePackager.class);
+
+        // set up callback
+        BridgeUddProcessor callback = new BridgeUddProcessor();
+        callback.setDynamoHelper(mockDynamoHelper);
+        callback.setSesHelper(mockSesHelper);
+        callback.setStormpathHelper(mockStormpathHelper);
+        callback.setSynapsePackager(mockPackager);
+
+        // execute
+        try {
+            callback.process(requestJson);
+            fail("expected exception");
+        } catch (PollSqsWorkerBadRequestException ex) {
+            // expected exception
+        }
+
+        // verify SesHelper calls
+        verifyZeroInteractions(mockPackager, mockSesHelper);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/udd/worker/BridgeUddProcessorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/worker/BridgeUddProcessorTest.java
@@ -33,30 +33,30 @@ import org.sagebionetworks.bridge.udd.synapse.SynapsePackager;
 public class BridgeUddProcessorTest {
     // mock objects - These are used only as passthroughs between the sub-components. So just create mocks instead
     // of instantiating all the fields.
-    private static final StudyInfo MOCK_STUDY_INFO = mock(StudyInfo.class);
-    private static final Map<String, UploadSchema> MOCK_SYNAPSE_TO_SCHEMA = ImmutableMap.of();
-    private static final Set<String> MOCK_SURVEY_TABLE_ID_SET = ImmutableSet.of();
-    private static final PresignedUrlInfo MOCK_PRESIGNED_URL_INFO = mock(PresignedUrlInfo.class);
+    public static final StudyInfo MOCK_STUDY_INFO = mock(StudyInfo.class);
+    public static final Map<String, UploadSchema> MOCK_SYNAPSE_TO_SCHEMA = ImmutableMap.of();
+    public static final Set<String> MOCK_SURVEY_TABLE_ID_SET = ImmutableSet.of();
+    public static final PresignedUrlInfo MOCK_PRESIGNED_URL_INFO = mock(PresignedUrlInfo.class);
 
     // simple strings for test
-    private static final String EMAIL = "test@example.com";
-    private static final String HEALTH_CODE = "test-health-code";
-    private static final String HEALTH_ID = "test-health-id";
-    private static final String STUDY_ID = "test-study";
+    public static final String EMAIL = "test@example.com";
+    public static final String HEALTH_CODE = "test-health-code";
+    public static final String HEALTH_ID = "test-health-id";
+    public static final String STUDY_ID = "test-study";
 
     // non-mock test objects - We break inside these objects to get data.
-    private static final AccountInfo ACCOUNT_INFO = new AccountInfo.Builder().withEmailAddress(EMAIL)
+    public static final AccountInfo ACCOUNT_INFO = new AccountInfo.Builder().withEmailAddress(EMAIL)
             .withHealthId(HEALTH_ID).withUsername(EMAIL).build();
 
     // test request
-    private static final String REQUEST_JSON_TEXT = "{\n" +
+    public static final String REQUEST_JSON_TEXT = "{\n" +
             "   \"studyId\":\"" + STUDY_ID +"\",\n" +
             "   \"username\":\"" + EMAIL + "\",\n" +
             "   \"startDate\":\"2015-03-09\",\n" +
             "   \"endDate\":\"2015-03-31\"\n" +
             "}";
 
-    private static final String INVALID_JSON_TEXT = "{\n" +
+    public static final String INVALID_JSON_TEXT = "{\n" +
             "   \"invalidType\":\"" + STUDY_ID +"\",\n" +
             "   \"username\":\"" + EMAIL + "\",\n" +
             "   \"startDate\":\"2015-03-09\",\n" +
@@ -65,8 +65,6 @@ public class BridgeUddProcessorTest {
 
     private JsonNode requestJson;
     private JsonNode invalidRequestJson;
-
-
 
     // test members
     private BridgeUddProcessor callback;


### PR DESCRIPTION
Under some weird circumstances, accounts sometimes have no health code. (This almost never comes up, except when testing directly in SQS.) This adds a null-check so we can properly throw a PollSqsWorkerBadRequestException instead of a NullPointerException.

Testing done:
* mvn verify (unit tests, findbugs, jacoco test coverage)
* manually tested in Worker Platform, both missing health code case and normal case