### PR TITLE
request using User ID and Bridge instead of email and Stormpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>BridgeUserDataDownloadService</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -93,6 +93,11 @@
             <groupId>org.sagebionetworks</groupId>
             <artifactId>synapseJavaClient</artifactId>
             <version>157.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.sagebionetworks.bridge</groupId>
+            <artifactId>rest-client</artifactId>
+            <version>0.12.71</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/sagebionetworks/bridge/udd/accounts/AccountInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/accounts/AccountInfo.java
@@ -1,17 +1,22 @@
 package org.sagebionetworks.bridge.udd.accounts;
 
 import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
 
 /** Encapsulates account information. */
 public class AccountInfo {
     private final String emailAddress;
+    private final String healthCode;
     private final String healthId;
+    private final String userId;
     private final String username;
 
     /** Private constructor. Construction should go through the builder. */
-    private AccountInfo(String emailAddress, String healthId, String username) {
+    private AccountInfo(String emailAddress, String healthCode, String healthId, String userId, String username) {
         this.emailAddress = emailAddress;
+        this.healthCode = healthCode;
         this.healthId = healthId;
+        this.userId = userId;
         this.username = username;
     }
 
@@ -20,9 +25,19 @@ public class AccountInfo {
         return emailAddress;
     }
 
+    /** Account's health code. This is available in the getParticipant API in Bridge, but not in Stormpath. */
+    public String getHealthCode() {
+        return healthCode;
+    }
+
     /** Account's health ID, which is used to obtain the health code. */
     public String getHealthId() {
         return healthId;
+    }
+
+    /** Account's ID. */
+    public String getUserId() {
+        return userId;
     }
 
     /** Account's username. */
@@ -30,10 +45,24 @@ public class AccountInfo {
         return username;
     }
 
+    /**
+     * Helper method to either return userId or a hash of the username (email), for use in the logs. This can be
+     * removed when we remove all the Stormpath stuff, and everything uses userId.
+     */
+    public String getLogId() {
+        if (StringUtils.isNotBlank(userId)) {
+            return userId;
+        } else {
+            return "hash[username]=" + username.hashCode();
+        }
+    }
+
     /** Builder for AccountInfo. */
     public static class Builder {
         private String emailAddress;
+        private String healthCode;
         private String healthId;
+        private String userId;
         private String username;
 
         /** @see AccountInfo#getEmailAddress */
@@ -42,9 +71,21 @@ public class AccountInfo {
             return this;
         }
 
+        /** @see AccountInfo#getHealthCode */
+        public Builder withHealthCode(String healthCode) {
+            this.healthCode = healthCode;
+            return this;
+        }
+
         /** @see AccountInfo#getHealthId */
         public Builder withHealthId(String healthId) {
             this.healthId = healthId;
+            return this;
+        }
+
+        /** @see AccountInfo#getUserId */
+        public Builder withUserId(String userId) {
+            this.userId = userId;
             return this;
         }
 
@@ -60,15 +101,15 @@ public class AccountInfo {
                 throw new IllegalStateException("emailAddress must be specified");
             }
 
-            if (Strings.isNullOrEmpty(healthId)) {
-                throw new IllegalStateException("healthId must be specified");
+            if (Strings.isNullOrEmpty(healthCode) && Strings.isNullOrEmpty(healthId)) {
+                throw new IllegalStateException("either healthCode or healthId must be specified");
             }
 
-            if (Strings.isNullOrEmpty(username)) {
-                throw new IllegalStateException("username must be specified");
+            if (Strings.isNullOrEmpty(userId) && Strings.isNullOrEmpty(username)) {
+                throw new IllegalStateException("either userId or username must be specified");
             }
 
-            return new AccountInfo(emailAddress, healthId, username);
+            return new AccountInfo(emailAddress, healthCode, healthId, userId, username);
         }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/udd/accounts/BridgeHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/accounts/BridgeHelper.java
@@ -1,0 +1,30 @@
+package org.sagebionetworks.bridge.udd.accounts;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.rest.ClientManager;
+import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
+import org.sagebionetworks.bridge.rest.model.StudyParticipant;
+
+/** Helper to call Bridge server. */
+@Component
+public class BridgeHelper {
+    private ClientManager bridgeClientManager;
+
+    /** Bridge client. */
+    @Autowired
+    public final void setBridgeClientManager(ClientManager bridgeClientManager) {
+        this.bridgeClientManager = bridgeClientManager;
+    }
+
+    /** Gets account information (email address, healthcode) for the given account ID. */
+    public AccountInfo getAccountInfo(String studyId, String userId) throws IOException {
+        StudyParticipant participant = bridgeClientManager.getClient(ForWorkersApi.class).getParticipantInStudy(
+                studyId, userId).execute().body();
+        return new AccountInfo.Builder().withEmailAddress(participant.getEmail())
+                .withHealthCode(participant.getHealthCode()).withUserId(userId).build();
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/udd/config/SpringConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/config/SpringConfig.java
@@ -19,8 +19,6 @@ import com.stormpath.sdk.client.Client;
 import com.stormpath.sdk.client.Clients;
 import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.config.PropertiesConfig;
-import org.sagebionetworks.client.SynapseAdminClientImpl;
-import org.sagebionetworks.client.SynapseClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -29,6 +27,9 @@ import org.sagebionetworks.bridge.crypto.AesGcmEncryptor;
 import org.sagebionetworks.bridge.crypto.Encryptor;
 import org.sagebionetworks.bridge.dynamodb.DynamoQueryHelper;
 import org.sagebionetworks.bridge.heartbeat.HeartbeatLogger;
+import org.sagebionetworks.bridge.rest.ClientManager;
+import org.sagebionetworks.bridge.rest.model.ClientInfo;
+import org.sagebionetworks.bridge.rest.model.SignIn;
 import org.sagebionetworks.bridge.s3.S3Helper;
 
 // These configs get credentials from the default credential chain. For developer desktops, this is ~/.aws/credentials.
@@ -41,6 +42,18 @@ public class SpringConfig {
     private static final String CONFIG_FILE = "BridgeUserDataDownloadService.conf";
     private static final String DEFAULT_CONFIG_FILE = CONFIG_FILE;
     private static final String USER_CONFIG_FILE = System.getProperty("user.home") + "/" + CONFIG_FILE;
+
+    @Bean
+    public ClientManager bridgeClientManager() throws IOException {
+        Config config = bridgeConfig();
+        String study = config.get("bridge.worker.study");
+        String email = config.get("bridge.worker.email");
+        String password = config.get("bridge.worker.password");
+        SignIn bridgeCredentials = new SignIn().study(study).email(email).password(password);
+
+        ClientInfo clientInfo = new ClientInfo().appName("BridgeUDD").appVersion(1);
+        return new ClientManager.Builder().withClientInfo(clientInfo).withSignIn(bridgeCredentials).build();
+    }
 
     @Bean(name = "uddConfigProperties")
     public Config bridgeConfig() {

--- a/src/main/java/org/sagebionetworks/bridge/udd/helper/SesHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/helper/SesHelper.java
@@ -117,7 +117,7 @@ public class SesHelper {
         SendEmailRequest sendEmailRequest = new SendEmailRequest(fromAddress, destination, message);
         SendEmailResult sendEmailResult = sesClient.sendEmail(sendEmailRequest);
 
-        LOG.info("Sent email to hash[username]=" + accountInfo.getUsername().hashCode() + " with SES message ID " +
+        LOG.info("Sent email to account " + accountInfo.getLogId() + " with SES message ID " +
                 sendEmailResult.getMessageId());
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/udd/worker/BridgeUddRequest.java
+++ b/src/main/java/org/sagebionetworks/bridge/udd/worker/BridgeUddRequest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.udd.worker;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.joda.deser.LocalDateDeserializer;
@@ -10,15 +11,18 @@ import org.sagebionetworks.bridge.json.LocalDateToStringSerializer;
 
 /** Represents a request to the Bridge User Data Download Service. */
 @JsonDeserialize(builder = BridgeUddRequest.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class BridgeUddRequest {
     private final String studyId;
+    private final String userId;
     private final String username;
     private final LocalDate startDate;
     private final LocalDate endDate;
 
     /** Private constructor. To construct, use builder. */
-    private BridgeUddRequest(String studyId, String username, LocalDate startDate, LocalDate endDate) {
+    private BridgeUddRequest(String studyId, String userId, String username, LocalDate startDate, LocalDate endDate) {
         this.studyId = studyId;
+        this.userId = userId;
         this.username = username;
         this.startDate = startDate;
         this.endDate = endDate;
@@ -27,6 +31,11 @@ public class BridgeUddRequest {
     /** ID of the study to get user data from. */
     public String getStudyId() {
         return studyId;
+    }
+
+    /** ID of the user requesting their data. */
+    public String getUserId() {
+        return userId;
     }
 
     /** Username of the user requesting their data. */
@@ -49,6 +58,7 @@ public class BridgeUddRequest {
     /** Bridge-UDD request builder. */
     public static class Builder {
         private String studyId;
+        private String userId;
         private String username;
         private LocalDate startDate;
         private LocalDate endDate;
@@ -56,6 +66,12 @@ public class BridgeUddRequest {
         /** @see BridgeUddRequest#getStudyId */
         public Builder withStudyId(String studyId) {
             this.studyId = studyId;
+            return this;
+        }
+
+        /** @see BridgeUddRequest#getUserId */
+        public Builder withUserId(String userId) {
+            this.userId = userId;
             return this;
         }
 
@@ -88,8 +104,8 @@ public class BridgeUddRequest {
                 throw new IllegalStateException("studyId must be specified");
             }
 
-            if (Strings.isNullOrEmpty(username)) {
-                throw new IllegalStateException("username must be specified");
+            if (Strings.isNullOrEmpty(userId) && Strings.isNullOrEmpty(username)) {
+                throw new IllegalStateException("either userId or username must be specified");
             }
 
             if (startDate == null) {
@@ -104,7 +120,7 @@ public class BridgeUddRequest {
                 throw new IllegalStateException("startDate can't be after endDate");
             }
 
-            return new BridgeUddRequest(studyId, username, startDate, endDate);
+            return new BridgeUddRequest(studyId, userId, username, startDate, endDate);
         }
     }
 }

--- a/src/main/resources/BridgeUserDataDownloadService.conf
+++ b/src/main/resources/BridgeUserDataDownloadService.conf
@@ -1,6 +1,10 @@
 bridge.env=local
 bridge.user=your-username-here
 
+bridge.worker.study=your-worker-account-here
+bridge.worker.email=your-worker-account-here
+bridge.worker.password=your-worker-account-here
+
 health.code.key = your-key-here
 
 stormpath.id = your-id-here

--- a/src/test/java/org/sagebionetworks/bridge/udd/accounts/AccountInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/accounts/AccountInfoTest.java
@@ -1,6 +1,8 @@
 package org.sagebionetworks.bridge.udd.accounts;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import org.testng.annotations.Test;
 
@@ -39,11 +41,28 @@ public class AccountInfoTest {
     }
 
     @Test
-    public void happyCase() {
+    public void healthIdAndUsername() {
         AccountInfo accountInfo = new AccountInfo.Builder().withEmailAddress("dummy-email@example.com")
                 .withHealthId("dummy-health-id").withUsername("dummy-username").build();
         assertEquals(accountInfo.getEmailAddress(), "dummy-email@example.com");
         assertEquals(accountInfo.getHealthId(), "dummy-health-id");
         assertEquals(accountInfo.getUsername(), "dummy-username");
+
+        // log ID contains a hash of the username (and the prefix "hash[username]="), but not the username itself
+        String logId = accountInfo.getLogId();
+        assertTrue(logId.startsWith("hash[username]="));
+        assertFalse(logId.contains("dummy-username"));
+    }
+
+    @Test
+    public void healthCodeAndUserId() {
+        AccountInfo accountInfo = new AccountInfo.Builder().withEmailAddress("dummy-email@example.com")
+                .withHealthCode("dummy-health-code").withUserId("dummy-user-id").build();
+        assertEquals(accountInfo.getEmailAddress(), "dummy-email@example.com");
+        assertEquals(accountInfo.getHealthCode(), "dummy-health-code");
+        assertEquals(accountInfo.getUserId(), "dummy-user-id");
+
+        // log ID is just user ID
+        assertEquals(accountInfo.getLogId(), accountInfo.getUserId());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/udd/accounts/BridgeHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/accounts/BridgeHelperTest.java
@@ -1,0 +1,49 @@
+package org.sagebionetworks.bridge.udd.accounts;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+import retrofit2.Call;
+import retrofit2.Response;
+
+import org.sagebionetworks.bridge.rest.ClientManager;
+import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
+import org.sagebionetworks.bridge.rest.model.StudyParticipant;
+
+@SuppressWarnings("unchecked")
+public class BridgeHelperTest {
+    private static final String EMAIL = "eggplant@example.com";
+    private static final String HEALTH_CODE = "dummy-health-code";
+    private static final String STUDY_ID = "test-study";
+    private static final String USER_ID = "dummy-user-id";
+
+    @Test
+    public void getAccountInfo() throws Exception {
+        // mock StudyParticipant - We can't set the healthcode, but we need to return it for test.
+        StudyParticipant mockParticipant = mock(StudyParticipant.class);
+        when(mockParticipant.getEmail()).thenReturn(EMAIL);
+        when(mockParticipant.getHealthCode()).thenReturn(HEALTH_CODE);
+
+        // mock bridge calls
+        Response<StudyParticipant> response = Response.success(mockParticipant);
+        Call<StudyParticipant> mockCall = mock(Call.class);
+        when(mockCall.execute()).thenReturn(response);
+
+        ForWorkersApi mockWorkerApi = mock(ForWorkersApi.class);
+        when(mockWorkerApi.getParticipantInStudy(STUDY_ID, USER_ID)).thenReturn(mockCall);
+
+        ClientManager mockClientManager = mock(ClientManager.class);
+        when(mockClientManager.getClient(ForWorkersApi.class)).thenReturn(mockWorkerApi);
+
+        BridgeHelper bridgeHelper = new BridgeHelper();
+        bridgeHelper.setBridgeClientManager(mockClientManager);
+
+        // execute and validate
+        AccountInfo accountInfo = bridgeHelper.getAccountInfo(STUDY_ID, USER_ID);
+        assertEquals(accountInfo.getEmailAddress(), EMAIL);
+        assertEquals(accountInfo.getHealthCode(), HEALTH_CODE);
+        assertEquals(accountInfo.getUserId(), USER_ID);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/udd/worker/BridgeUddRequestTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/udd/worker/BridgeUddRequestTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.joda.time.LocalDate;
 import org.testng.annotations.Test;
 
@@ -76,6 +77,16 @@ public class BridgeUddRequestTest {
     }
 
     @Test
+    public void withUserId() {
+        BridgeUddRequest request = new BridgeUddRequest.Builder().withStudyId("test-study").withUserId("test-user-id")
+                .withStartDate(LocalDate.parse("2015-08-15")).withEndDate(LocalDate.parse("2015-08-19")).build();
+        assertEquals(request.getStudyId(), "test-study");
+        assertEquals(request.getUserId(), "test-user-id");
+        assertEquals(request.getStartDate().toString(), "2015-08-15");
+        assertEquals(request.getEndDate().toString(), "2015-08-19");
+    }
+
+    @Test
     public void jsonSerialization() throws Exception {
         // start with JSON
         String jsonText = "{\n" +
@@ -102,5 +113,31 @@ public class BridgeUddRequestTest {
         assertEquals(jsonMap.get("username"), "json-user");
         assertEquals(jsonMap.get("startDate"), "2015-08-03");
         assertEquals(jsonMap.get("endDate"), "2015-08-07");
+    }
+
+    @Test
+    public void jsonSerializationWithUserId() throws Exception {
+        // start with JSON
+        String jsonText = "{\n" +
+                "   \"studyId\":\"json-study\",\n" +
+                "   \"userId\":\"json-user-id\",\n" +
+                "   \"startDate\":\"2015-08-03\",\n" +
+                "   \"endDate\":\"2015-08-07\"\n" +
+                "}";
+
+        // convert to POJO
+        BridgeUddRequest request = DefaultObjectMapper.INSTANCE.readValue(jsonText, BridgeUddRequest.class);
+        assertEquals(request.getStudyId(), "json-study");
+        assertEquals(request.getUserId(), "json-user-id");
+        assertEquals(request.getStartDate().toString(), "2015-08-03");
+        assertEquals(request.getEndDate().toString(), "2015-08-07");
+
+        // convert back to JSON
+        JsonNode jsonNode = DefaultObjectMapper.INSTANCE.convertValue(request, JsonNode.class);
+        assertEquals(4, jsonNode.size());
+        assertEquals(jsonNode.get("studyId").textValue(), "json-study");
+        assertEquals(jsonNode.get("userId").textValue(), "json-user-id");
+        assertEquals(jsonNode.get("startDate").textValue(), "2015-08-03");
+        assertEquals(jsonNode.get("endDate").textValue(), "2015-08-07");
     }
 }


### PR DESCRIPTION
This allows UDD to get user info using User ID and Bridge Server instead of email and Stormpath. This is the first step to removing Stormpath from UDD.

Testing done:
* mvn verify (unit tests, findbugs, jacoco test coverage)
* manually tested both Bridge and Stormpath code paths

Next steps: change BridgeServer to call this new API, then remove the Stormpath code